### PR TITLE
remove mentions of deferred status

### DIFF
--- a/puzzle_editing/status.py
+++ b/puzzle_editing/status.py
@@ -42,7 +42,7 @@ def past_testsolving(status):
     ) <= get_status_rank(DONE)
 
 
-# a partition of the statuses that excludes Done, Deferred, Dead for some queries
+# a partition of the statuses that excludes Done or Dead for some queries
 PRE_TESTSOLVING_STATUSES = STATUSES[: STATUSES.index(TESTSOLVING)]
 POST_TESTSOLVING_STATUSES = STATUSES[STATUSES.index(TESTSOLVING) : STATUSES.index(DONE)]
 

--- a/puzzle_editing/templates/editors.html
+++ b/puzzle_editing/templates/editors.html
@@ -6,7 +6,7 @@ Editors
 {% block main %}
 	<h1>Editors + Editing Puzzles</h1>
 	<p>Shows all users with the editor role or editing at least one puzzle.</p>
-	<p>* "Active" means any status other than Deferred, Dead, or Done.</p>
+	<p>* "Active" means any status other than Dead or Done.</p>
 	<div class="table-wrap">
 	<table class="classic sortable">
 		<thead>

--- a/puzzle_editing/templates/users.html
+++ b/puzzle_editing/templates/users.html
@@ -5,7 +5,7 @@ Users
 {% endblock %}
 {% block main %}
 	<h1>Users</h1>
-	<p>* "Active" means any status other than Deferred, Dead, or Done. See also <a href="{% url 'users_statuses' %}">Users &times; Statuses</a>, more detailed <a href="{% url 'editors' %}">Editors + Editing Puzzles</a></p>
+	<p>* "Active" means any status other than Dead or Done. See also <a href="{% url 'users_statuses' %}">Users &times; Statuses</a>, more detailed <a href="{% url 'editors' %}">Editors + Editing Puzzles</a></p>
 	<div class="table-wrap">
 	<table class="classic sortable">
 		<thead>


### PR DESCRIPTION
Original puzzlord had a deferred status that STA removed, because it was less useful for smaller hunts. This just removes references to it to avoid confusion.